### PR TITLE
Update main.scss

### DIFF
--- a/normalize/main.scss
+++ b/normalize/main.scss
@@ -232,14 +232,4 @@
 	/* Next specific stuff
 		=====================================================================*/
 
-	/**
-	* Standardise outline styles
-	* This will be phased out...
-	*/
-
-	:focus {
-		outline: thin dotted;
-		outline-offset: 1px;
-	}
-
 }

--- a/normalize/main.scss
+++ b/normalize/main.scss
@@ -39,11 +39,6 @@
 		outline-width: 0 !important;
 	}
 
-	a:focus {
-		outline: 3px solid getColor('teal-40');
-		outline-offset: 3px;
-	}
-
 	/* Text-level semantics
 		=====================================================================*/
 


### PR DESCRIPTION
Removes old outlines

This will allow the new focus styles to take over. Can be safely released after the migration.