### PR TITLE
Put o-typography back to silent mode

### DIFF
--- a/typography/main.scss
+++ b/typography/main.scss
@@ -1,6 +1,3 @@
-$o-typography-is-silent: false;
-$o-typography-load-fonts: false;
-
 @import 'o-fonts/main';
 @import 'o-typography/main';
 


### PR DESCRIPTION
There are no user-facing products relying on this, so _should_ be a safe
way to save a few CSS bytes.