### PR TITLE
Remove old o-typography styles

### DIFF
--- a/typography/main.scss
+++ b/typography/main.scss
@@ -30,17 +30,12 @@
 	@include oFontsInclude(FinancierDisplayWeb, $weight: bold);
 	@include oFontsInclude(MetricWeb);
 	@include oFontsInclude(MetricWeb, $weight: semibold);
+
 	html {
 		//TODO - move elsewhere??
 		@include oColorsFor(page);
 		font-family: sans-serif;
 		font-size: 0.8125em;
-
-		// scss-lint:disable SelectorFormat
-		&.o-typography--loaded-sans {
-			font-family: $o-typography-sans;
-			font-size: initial;
-		}
 	}
 
 	// cannot use oTypographyLink because it will make an ".o-hoverable-on a" class which will override BEM styles


### PR DESCRIPTION
o-typography no longer uses `o-typography--loaded-x` classes. Now it’s
kind-of reversed, where it [outputs extra styles for the loading state instead](https://github.com/Financial-Times/o-typography/blob/master/src/scss/_mixins.scss#L91). However, we seem to be getting on fine without them, so let’s just remove these bits rather than replace them.