### PR TITLE
Smooth out text in macOS Firefox

### DIFF
--- a/normalize/main.scss
+++ b/normalize/main.scss
@@ -7,7 +7,7 @@
 
 	html {
 		// scss-lint:disable VendorPrefix
-		-moz-osx-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
 		-webkit-font-smoothing: antialiased;
 		-ms-text-size-adjust: 100%;
 		-webkit-text-size-adjust: 100%;

--- a/normalize/main.scss
+++ b/normalize/main.scss
@@ -1,14 +1,18 @@
 @mixin nUiNormalize {
 
 	/**
-	* Prevent adjustments of font size after orientation changes in IE and iOS.
+	* Apply font smoothing;
+	* Prevent adjustments of font size after orientation changes in IE and iOS
 	*/
 
 	html {
+		// scss-lint:disable VendorPrefix
+		-moz-osx-font-smoothing: antialiased;
+		-webkit-font-smoothing: antialiased;
 		-ms-text-size-adjust: 100%;
 		-webkit-text-size-adjust: 100%;
+		// scss-lint:enable VendorPrefix
 		text-rendering: optimizeLegibility;
-		-webkit-font-smoothing: antialiased;
 	}
 
 	/**


### PR DESCRIPTION
A baby step towards [moving over to o-normalise](https://github.com/Financial-Times/o-normalise/blob/0a9fa7a69543e4248d2b7024d688e2e8648bc085/src/scss/_mixins.scss#L69) that happens to cater to our immediate needs 😬 (fixes firefox rendering of the myFT section on the front page)