### PR TITLE
Add MetricWeb medium font face.

### DIFF
--- a/typography/main.scss
+++ b/typography/main.scss
@@ -11,6 +11,7 @@
 	@include oFontsInclude(FinancierDisplayWeb, $weight: bold);
 	@include oFontsInclude(MetricWeb);
 	@include oFontsInclude(MetricWeb, $weight: semibold);
+	@include oFontsInclude(MetricWeb, $weight: medium);
 
 	html {
 		//TODO - move elsewhere??


### PR DESCRIPTION
Adds MetricWeb `medium` (500) font face. This **does not** include a new font file, as it uses the same font file as the `semibold` (600) font face.

Stream pages include `o-teaser` which uses `font-weight: 500` in its label, however no font face for a weight of 500 is included in the head of the stream page. The effect is a thin looking label:

<img width="109" alt="Screenshot 2019-03-28 at 09 53 52" src="https://user-images.githubusercontent.com/10405691/55148800-da13d380-5140-11e9-830c-a61dfb9b12c1.png">

Which should look like this:
<img width="110" alt="Screenshot 2019-03-28 at 09 53 56" src="https://user-images.githubusercontent.com/10405691/55148801-da13d380-5140-11e9-9839-cb6db76a9573.png">

