### PR TITLE
Unpin @financial-times/n-gage

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/Financial-Times/n-ui-foundations#readme",
   "devDependencies": {
-    "@financial-times/n-gage": "3.5.0",
+    "@financial-times/n-gage": "^3.6.0",
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
     "babel-plugin-add-module-exports": "^0.2.1",


### PR DESCRIPTION
This pull requests unpins the @financial-times/n-gage dependency. As a general rule we should not be pinning any of our devDependencies. Please merge this pull requests if all checks are passing.