### PR TITLE
Support o-date v2 or v3.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "ftdomdelegate": "^3.0.0",
     "o-buttons": ">=4.0.0 <6",
     "o-colors": "^4.0.1",
-    "o-date": "^3.1.0",
+    "o-date": ">=2.14.0 <4",
     "o-grid": "^4.4.4",
     "o-icons": ">=4.0.0 <6",
     "o-normalise": "^1.4.2",


### PR DESCRIPTION
o-date was recently migrated to v3 (n-ui-foundations@v3.1.0).
This has caused conflicts for projects which depend on
n-ui-foundations and o-date@v2. I.e. builds may fail,
requiring user intervention, and build service requests may
also fail (impacting production apps).

Here's one I've seen:
`/v2/bundles/js?modules=o-grid@^4.3.7,o-colors@^4.1.5,o-normalise@^1.5.3,o-footer@^6.0.8,o-header-services@^2.0.5,o-fonts@^3.0.4,o-typography@^5.4.2,o-table@^6.5.0,o-forms@^5.0.1,o-buttons@^5.8.5,o-overlay@^2.2.0,o-date@^2.10.3,n-alert-banner@^1.0.0,o-tracking@^1.3.8,o-tooltip@^3.1.2`
_(n-alert-banner requires n-ui-foundations)_

As o-date v2 and v3 have the same interface we can use a range
to allow either.

Alternatively, we would have to revert and release a major of
n-ui-foundations.