### PR TITLE
Do not output a snappy grid by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ Delete the given cookie by setting the expiry to the past.
 
 ## Migration guides
 
+### v4 to v5
+
+v5 of n-ui-foundations no longer outputs a [snappy grid](https://github.com/Financial-Times/o-grid#snappy-mode) by default, as it is deprecated. This means your grid container elements will be wider when the viewport width is at a [grid breakpoint](https://github.com/Financial-Times/o-grid#layout-sizes). Where the grid CSS class `o-grid-container` or Sass mixin `oGridContainer` is used check your project at different breakpoints for visual regressions. If your project looks good no action is needed.
+
+If your project looks broken, you may choose to switch to a `snappy` grid. This will allow us to find where the snappy grid is used and remove it in the future:
+- Find and replace `o-grid-container` classes with `o-grid-container o-grid-container--snappy`.
+```diff
+-<div class="o-grid-container"></div>
++<div class="o-grid-container o-grid-container--snappy"></div>
+```
+- Find `oGridContainer` mixin uses and pass `snappy` as the first argument.
+```diff
+-@include oGridContainer();
++@include oGridContainer($grid-mode: 'snappy');
+```
+
 ### v3 to v4
 
 - All color use cases have been removed as many of these are already defined by `o-` components and should be used instead.

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ Delete the given cookie by setting the expiry to the past.
 
 ## Migration guides
 
-### v4 to v5
+### v5 to v6
 
-v5 of n-ui-foundations no longer outputs a [snappy grid](https://github.com/Financial-Times/o-grid#snappy-mode) by default, as it is deprecated. This means your grid container elements will be wider when the viewport width is at a [grid breakpoint](https://github.com/Financial-Times/o-grid#layout-sizes). Where the grid CSS class `o-grid-container` or Sass mixin `oGridContainer` is used check your project at different breakpoints for visual regressions. If your project looks good no action is needed.
+v6 of n-ui-foundations no longer outputs a [snappy grid](https://github.com/Financial-Times/o-grid#snappy-mode) by default, as it is deprecated. This means your grid container elements will be wider when the viewport width is at a [grid breakpoint](https://github.com/Financial-Times/o-grid#layout-sizes). Where the grid CSS class `o-grid-container` or Sass mixin `oGridContainer` is used check your project at different breakpoints for visual regressions. If your project looks good no action is needed.
 
 If your project looks broken, you may choose to switch to a `snappy` grid. This will allow us to find where the snappy grid is used and remove it in the future:
 - Find and replace `o-grid-container` classes with `o-grid-container o-grid-container--snappy`.
@@ -129,6 +129,12 @@ If your project looks broken, you may choose to switch to a `snappy` grid. This 
 -@include oGridContainer();
 +@include oGridContainer($grid-mode: 'snappy');
 ```
+
+### v4 to v5
+
+- No manual changes required, but font changes will occur:
+  - Added: Financier Medium.
+  - Removed: Metric Medium.
 
 ### v3 to v4
 

--- a/grid/main.scss
+++ b/grid/main.scss
@@ -1,11 +1,10 @@
-$o-grid-mode: snappy;
-
 @import 'o-grid/main';
 @import 'mixins';
 
 @mixin nUiGrid {
 	@include oGrid($opts: (
 		'bleed': true,
+		'snappy': true,
 		'shuffle-selectors': false,
 		'friendly-selectors': false,
 		'surface': ('current-layout'),


### PR DESCRIPTION
The snappy grid has a container which is smaller than the viewport
at each breakpoint [see snappy grid demo](https://www.ft.com/__origami/service/build/v2/demos/o-grid@4.5.3/snappy).
The standard fluid grid is always full bleed at each breakpoint,
until the max container size is reached [see fluid grid demo](https://www.ft.com/__origami/service/build/v2/demos/o-grid@4.5.3/default).

The snappy grid is deprecated and not recommended for new projects.
Going forward not all projects that use `n-ui-foundations` want
to use use a snappy grid, for example `ft-app`.

As this changes the layout of projects it should be considered
a breaking change in case it causes visually regressions. The
snappy grid is still available however so the migration step
is low cost (two find and replaces). For projects like `ft-app`
which no longer rely on the snappy grid, the annoying deprecation
warning will go away :tada:

See the README for more details.