### PR TITLE
Upgrade Node to v14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@
 
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node14: &container_config_node14
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:14-browsers
 
   workspace_root: &workspace_root
     ~/project
@@ -55,7 +55,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node14
     steps:
       - checkout
       - run:
@@ -88,7 +88,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node14
     steps:
       - *attach_workspace
       - run:
@@ -104,7 +104,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node8
+    <<: *container_config_node14
     steps:
       - *attach_workspace
       - run:

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "chai": "^4.0.0",
     "mocha": "^6.0.0"
   },
-  "config": {}
+  "config": {},
+  "engines": {
+    "node": "14.x"
+  }
 }


### PR DESCRIPTION
Please run appropriate tests and checks to ensure that the app is compatible with this Node version. https://node.green is a useful reference.<br/><br/>This PR was created using a [nori](https://github.com/Financial-Times/nori) script 🍙<br/><br/>*Nori is a command-line application for managing changes across multiple (usually Github) repositories.*