### PR TITLE
Upgrade mocha ^6.0.0 -> ^8.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "chai": "^4.0.0",
-    "mocha": "^6.0.0"
+    "mocha": "^8.2.0"
   },
   "config": {},
   "engines": {


### PR DESCRIPTION
Jira card: [CPP-399](https://financialtimes.atlassian.net/secure/RapidBoard.jspa?rapidView=1051&modal=detail&selectedIssue=CPP-399) "n-ui-foundations - Address prototype pollution vulnerability"

This PR will fix one route to the vulnerability. The below screengrab indicates that `mocha` v8.2.0 uses a more recent version of `yargs-unparser`, which in turn uses a more recent version of `yargs`, which in turn uses a more recent version of `y18n`.

However, it will not fix the direct route to the vulnerability exposed via `mocha`'s direct relationship to `yargs`. This has been raised as an issue in `mochajs/mocha` (https://github.com/mochajs/mocha/issues/4513), but the maintainers are asking for a proof-of-concept to demonstrate how Mocha is vulnerable. I think this card may remain blocked until such time that they are willing to make the upgrade.

Admittedly we could wait for this upgrade before merging this PR as it will fix both exposures to the same vulnerability at the same time, but if they release the fix as a minor or patch then this repo will just need a new rebuild to consume that change meaning we're essentially doing the work for it now in this PR.

Side note: I wonder why `chai` and `mocha` are `dependencies` rather than `devDependencies`… 🤔 

![Screenshot 2020-11-27 at 14 46 37](https://user-images.githubusercontent.com/10484515/100460639-72551f00-30bf-11eb-926b-d855c0b118f2.png)