### PR TITLE
Set chai + mocha as devDependencies (i.e. not dependencies)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,6 @@ jobs:
       - run:
           name: shared-helper / npm-store-auth-token
           command: .circleci/shared-helpers/helper-npm-store-auth-token
-      - run: npx snyk monitor --org=customer-products --project-name=Financial-Times/n-ui-foundations
       - run:
           name: shared-helper / npm-version-and-publish-public
           command: .circleci/shared-helpers/helper-npm-version-and-publish-public

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-preset-es2015": "^6.22.0",
     "bower": "^1.8.8",
     "bower-webpack-plugin": "^0.1.9",
+    "chai": "^4.0.0",
     "eslint": "^3.15.0",
     "karma": "^3.1.1",
     "karma-browserstack-launcher": "^1.3.0",
@@ -47,15 +48,12 @@
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^2.0.2",
     "lintspaces-cli": "^0.6.0",
+    "mocha": "^6.0.0",
     "node-sass": "^4.13.0",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0",
     "snyk": "^1.168.0",
     "webpack": "^1.14.0"
-  },
-  "dependencies": {
-    "chai": "^4.0.0",
-    "mocha": "^6.0.0"
   },
   "config": {},
   "engines": {


### PR DESCRIPTION
As pointed out by @emortong in https://github.com/Financial-Times/n-ui-foundations/pull/92#issuecomment-734877955, there does not seem to be a reason as to why `chai` and `mocha` were added as `dependencies` rather than `devDependencies` back in this early PR https://github.com/Financial-Times/n-ui-foundations/pull/2.

Moving them into `devDependencies` also removes them from Snyk's analysis and means we won't need to worry about doing any vulnerability upgrades.

As this change will leave this repo's `package.json` without any `dependencies`, it means the `npx snyk monitor` command will fail, and so that command has also been removed.