### PR TITLE
add ftdomdelegate and superstore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,10 @@
         "@financial-times/o-typography": "^7.2.0",
         "@financial-times/o-utils": "^2.1.0",
         "@financial-times/o-viewport": "^5.1.0",
-        "@financial-times/o-visual-effects": "^4.1.0"
+        "@financial-times/o-visual-effects": "^4.1.0",
+        "ftdomdelegate": "^5.0.0",
+        "superstore": "^2.1.0",
+        "superstore-sync": "^2.1.1"
       },
       "devDependencies": {
         "@financial-times/n-gage": "^8.3.2",
@@ -8679,6 +8682,11 @@
       "engines": {
         "node": ">= 4.0"
       }
+    },
+    "node_modules/ftdomdelegate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ftdomdelegate/-/ftdomdelegate-5.0.0.tgz",
+      "integrity": "sha512-P9UmLMIq/ibxxFVBHlE2EIoHcFNDpamn3urRCwVWMnj3o9nAgLtqe64WVuqcGtkN4wujrBYeyxKCuN1/WO+bQw=="
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -18708,6 +18716,25 @@
         "postcss": "^7.0.2"
       }
     },
+    "node_modules/superstore": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/superstore/-/superstore-2.1.0.tgz",
+      "integrity": "sha1-TNbFsqiyQyXbn+Nz6V/IacHTsiU=",
+      "dependencies": {
+        "superstore-sync": "^2.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/superstore-sync": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/superstore-sync/-/superstore-sync-2.1.1.tgz",
+      "integrity": "sha512-p9UZQkOR0JKr4rJFwQubHff8+ktFg8LuIvwR3fYtjra2+m6dTA3LPkf6VQApZaRgaCkYzcDDgAIshM1Ejq0wxQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -27579,6 +27606,11 @@
         "nan": "^2.12.1"
       }
     },
+    "ftdomdelegate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ftdomdelegate/-/ftdomdelegate-5.0.0.tgz",
+      "integrity": "sha512-P9UmLMIq/ibxxFVBHlE2EIoHcFNDpamn3urRCwVWMnj3o9nAgLtqe64WVuqcGtkN4wujrBYeyxKCuN1/WO+bQw=="
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -35546,6 +35578,19 @@
       "requires": {
         "postcss": "^7.0.2"
       }
+    },
+    "superstore": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/superstore/-/superstore-2.1.0.tgz",
+      "integrity": "sha1-TNbFsqiyQyXbn+Nz6V/IacHTsiU=",
+      "requires": {
+        "superstore-sync": "^2.1.0"
+      }
+    },
+    "superstore-sync": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/superstore-sync/-/superstore-sync-2.1.1.tgz",
+      "integrity": "sha512-p9UZQkOR0JKr4rJFwQubHff8+ktFg8LuIvwR3fYtjra2+m6dTA3LPkf6VQApZaRgaCkYzcDDgAIshM1Ejq0wxQ=="
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,9 @@
     "@financial-times/o-typography": "^7.2.0",
     "@financial-times/o-utils": "^2.1.0",
     "@financial-times/o-viewport": "^5.1.0",
-    "@financial-times/o-visual-effects": "^4.1.0"
+    "@financial-times/o-visual-effects": "^4.1.0",
+    "ftdomdelegate": "^5.0.0",
+    "superstore": "^2.1.0",
+    "superstore-sync": "^2.1.1"
   }
 }


### PR DESCRIPTION
PageKit requires these missing packages which were removed unintentionally as part of Bower to NPM migration