### PR TITLE
cpp-748 moving origami components to peer and dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,12 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "ftdomdelegate": "^5.0.0",
+        "superstore": "^2.1.0",
+        "superstore-sync": "^2.1.1"
+      },
+      "devDependencies": {
+        "@financial-times/n-gage": "^8.3.2",
         "@financial-times/o-buttons": "^7.2.0",
         "@financial-times/o-colors": "^6.4.0",
         "@financial-times/o-fonts": "^5.2.0",
@@ -19,12 +25,6 @@
         "@financial-times/o-utils": "^2.1.0",
         "@financial-times/o-viewport": "^5.1.0",
         "@financial-times/o-visual-effects": "^4.1.0",
-        "ftdomdelegate": "^5.0.0",
-        "superstore": "^2.1.0",
-        "superstore-sync": "^2.1.1"
-      },
-      "devDependencies": {
-        "@financial-times/n-gage": "^8.3.2",
         "babel-core": "^6.22.1",
         "babel-loader": "^6.2.10",
         "babel-plugin-add-module-exports": "^0.2.1",
@@ -55,6 +55,18 @@
       "engines": {
         "node": "12.x",
         "npm": "7.x || 8.x"
+      },
+      "peerDependencies": {
+        "@financial-times/o-buttons": "^7.2.0",
+        "@financial-times/o-colors": "^6.4.0",
+        "@financial-times/o-fonts": "^5.2.0",
+        "@financial-times/o-grid": "^6.1.1",
+        "@financial-times/o-icons": "^7.2.0",
+        "@financial-times/o-normalise": "^3.2.0",
+        "@financial-times/o-typography": "^7.2.0",
+        "@financial-times/o-utils": "^2.1.0",
+        "@financial-times/o-viewport": "^5.1.0",
+        "@financial-times/o-visual-effects": "^4.1.0"
       }
     },
     "node_modules/@arcanis/slice-ansi": {
@@ -1299,12 +1311,14 @@
       "version": "1.23.1",
       "resolved": "https://registry.npmjs.org/@financial-times/fticons/-/fticons-1.23.1.tgz",
       "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA==",
+      "dev": true,
       "peer": true
     },
     "node_modules/@financial-times/math": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/math/-/math-1.1.0.tgz",
       "integrity": "sha512-de62A+grddYjBzOf5NogvRou2othrHThVxPKf4hWjEvTTMTisPDvVfc7jiVm3OvH7FyGImwrpPJN/u30NzeLmQ==",
+      "dev": true,
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -1991,6 +2005,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-brand/-/o-brand-4.2.0.tgz",
       "integrity": "sha512-i4i+7opK4QV6RO7NfsHvPhJNVDpc9wepQfAA5jZtNzzph1hyf1xTXKl8nclhcQUn+3XhAuQFZfRFcZH08eVi3Q==",
+      "dev": true,
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -2000,6 +2015,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-buttons/-/o-buttons-7.2.0.tgz",
       "integrity": "sha512-5EF/OoM5t+n0D4WkuEIpDnCVBhwp1HTcEgU/P6QAh/mM+Uy3YUV5jmSrg4Qh4yolJfFl1iJmy9aTuFQapaZnog==",
+      "dev": true,
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -2015,6 +2031,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-6.4.0.tgz",
       "integrity": "sha512-XgjHlughOZqJYHZcSof0SrUL3X0jBIVO+v0j1UBi8BfHW48J+AINqcRVbYrHthzzfrz7OH8pZSFCXtQu/aBUqg==",
+      "dev": true,
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -2027,6 +2044,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-fonts/-/o-fonts-5.2.0.tgz",
       "integrity": "sha512-rLaVAU4GUwlJBjZK345tWqqC5wq97vWcB5UrGGVyVJyL7kYQ0FnHRuhYaJFvU3Rv8aZpZaxnPs4W+Qb4/QZGlA==",
+      "dev": true,
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -2038,6 +2056,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.1.tgz",
       "integrity": "sha512-vv58Lvb3fSeQBl5nXt/0Vltp6g5lS6fxoxPjLK8VjdXZ1AlYnFA3eA052rBJXejxZOmeSEw9tMNvps/qIngXOg==",
+      "dev": true,
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -2050,6 +2069,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.2.0.tgz",
       "integrity": "sha512-ShWo6fGGjGBu/xAo5ScW/OAmg9ZY7hyqFw36E6+7dMuoy2+JBq/iNSKhQcFvHtp9zTZVkQxwCunGThooppOXHA==",
+      "dev": true,
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -2061,6 +2081,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.2.0.tgz",
       "integrity": "sha512-7xxoO0e/Gezf6fgZeDuJ425+bwYjilA4mkmkaGOJbLuVztSNJ4wshulNxuhz/fYy0ReL/SfedoAejcJasEoxlQ==",
+      "dev": true,
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -2073,6 +2094,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-spacing/-/o-spacing-3.2.0.tgz",
       "integrity": "sha512-iJQEBKQvv3dCtN5jHPp4ncSczMhVJoeSH3BkrUcyVBfetoAvXFI8e5AfaBAIQ61FXHzGoI7+D3UmPLFQHl1jNw==",
+      "dev": true,
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -2085,6 +2107,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-typography/-/o-typography-7.2.0.tgz",
       "integrity": "sha512-I1KPPpi5X9p7ax2FErOSL2V4/ICRhB6Fn4ONMalB2jJt5rRoIXEpK4pbweXkn54CEiwfI858/FYu2n+Gu+k2iw==",
+      "dev": true,
       "dependencies": {
         "fontfaceobserver": "^2.0.9"
       },
@@ -2105,6 +2128,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.1.0.tgz",
       "integrity": "sha512-tYtLU5e+rWedEnVrUYAqm5v8QVS7jBYyglIy8n7J1Bpam/fztcwTuqD2hf5kx8u7ITaapd4Bs0BJ+77k1fFWiw==",
+      "dev": true,
       "engines": {
         "npm": "^7 || ^8"
       }
@@ -2113,6 +2137,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-viewport/-/o-viewport-5.1.0.tgz",
       "integrity": "sha512-X7A6kA4jeSzZMLDI0bwDLpGou5UIdWj+0FzWhzfsT/ImN9kSMPotKa7T0QPc45OjbquYkWOr5ysq3TXKS2YQkw==",
+      "dev": true,
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -2124,6 +2149,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-visual-effects/-/o-visual-effects-4.1.0.tgz",
       "integrity": "sha512-u2FtZ6K/O1QgcwlvDkAwblAgkiAiZ4NNSBDVHuieAn1wB9HjiAvuzbUO66T2k25GfhfXEvmlHM4aAu2FFO7dTw==",
+      "dev": true,
       "engines": {
         "npm": "^7 || ^8"
       },
@@ -2135,6 +2161,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@financial-times/sass-mq/-/sass-mq-5.2.2.tgz",
       "integrity": "sha512-RmVzh2Reo67kCZoVJggJEJS+SjSJh1vct6mHYb0olmKYkpx3tNjTESNLDPfbSYyjW5Z3tCoaLF2FW9rqgWRnfg==",
+      "dev": true,
       "peer": true,
       "engines": {
         "npm": "^7 || ^8"
@@ -8554,7 +8581,8 @@
     "node_modules/fontfaceobserver": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
-      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng=="
+      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng==",
+      "dev": true
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -11578,6 +11606,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/mathsass/-/mathsass-0.10.1.tgz",
       "integrity": "sha1-h2j+ICEL1drqttZFxCx+aaTGAAg=",
+      "dev": true,
       "peer": true,
       "engines": {
         "node": ">=0.8.0",
@@ -21657,12 +21686,14 @@
       "version": "1.23.1",
       "resolved": "https://registry.npmjs.org/@financial-times/fticons/-/fticons-1.23.1.tgz",
       "integrity": "sha512-pBcOFpblNAUVl38Vez+WHpYlRC/gYkk30ANFiDWN7tUjKFsa2AbEMSJ2JBZsGEMvupPMBWKA/zsVqb29FmGnxA==",
+      "dev": true,
       "peer": true
     },
     "@financial-times/math": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/math/-/math-1.1.0.tgz",
       "integrity": "sha512-de62A+grddYjBzOf5NogvRou2othrHThVxPKf4hWjEvTTMTisPDvVfc7jiVm3OvH7FyGImwrpPJN/u30NzeLmQ==",
+      "dev": true,
       "peer": true,
       "requires": {}
     },
@@ -22186,48 +22217,56 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-brand/-/o-brand-4.2.0.tgz",
       "integrity": "sha512-i4i+7opK4QV6RO7NfsHvPhJNVDpc9wepQfAA5jZtNzzph1hyf1xTXKl8nclhcQUn+3XhAuQFZfRFcZH08eVi3Q==",
+      "dev": true,
       "peer": true
     },
     "@financial-times/o-buttons": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-buttons/-/o-buttons-7.2.0.tgz",
       "integrity": "sha512-5EF/OoM5t+n0D4WkuEIpDnCVBhwp1HTcEgU/P6QAh/mM+Uy3YUV5jmSrg4Qh4yolJfFl1iJmy9aTuFQapaZnog==",
+      "dev": true,
       "requires": {}
     },
     "@financial-times/o-colors": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-colors/-/o-colors-6.4.0.tgz",
       "integrity": "sha512-XgjHlughOZqJYHZcSof0SrUL3X0jBIVO+v0j1UBi8BfHW48J+AINqcRVbYrHthzzfrz7OH8pZSFCXtQu/aBUqg==",
+      "dev": true,
       "requires": {}
     },
     "@financial-times/o-fonts": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-fonts/-/o-fonts-5.2.0.tgz",
       "integrity": "sha512-rLaVAU4GUwlJBjZK345tWqqC5wq97vWcB5UrGGVyVJyL7kYQ0FnHRuhYaJFvU3Rv8aZpZaxnPs4W+Qb4/QZGlA==",
+      "dev": true,
       "requires": {}
     },
     "@financial-times/o-grid": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@financial-times/o-grid/-/o-grid-6.1.1.tgz",
       "integrity": "sha512-vv58Lvb3fSeQBl5nXt/0Vltp6g5lS6fxoxPjLK8VjdXZ1AlYnFA3eA052rBJXejxZOmeSEw9tMNvps/qIngXOg==",
+      "dev": true,
       "requires": {}
     },
     "@financial-times/o-icons": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-icons/-/o-icons-7.2.0.tgz",
       "integrity": "sha512-ShWo6fGGjGBu/xAo5ScW/OAmg9ZY7hyqFw36E6+7dMuoy2+JBq/iNSKhQcFvHtp9zTZVkQxwCunGThooppOXHA==",
+      "dev": true,
       "requires": {}
     },
     "@financial-times/o-normalise": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-normalise/-/o-normalise-3.2.0.tgz",
       "integrity": "sha512-7xxoO0e/Gezf6fgZeDuJ425+bwYjilA4mkmkaGOJbLuVztSNJ4wshulNxuhz/fYy0ReL/SfedoAejcJasEoxlQ==",
+      "dev": true,
       "requires": {}
     },
     "@financial-times/o-spacing": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-spacing/-/o-spacing-3.2.0.tgz",
       "integrity": "sha512-iJQEBKQvv3dCtN5jHPp4ncSczMhVJoeSH3BkrUcyVBfetoAvXFI8e5AfaBAIQ61FXHzGoI7+D3UmPLFQHl1jNw==",
+      "dev": true,
       "peer": true,
       "requires": {}
     },
@@ -22235,6 +22274,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-typography/-/o-typography-7.2.0.tgz",
       "integrity": "sha512-I1KPPpi5X9p7ax2FErOSL2V4/ICRhB6Fn4ONMalB2jJt5rRoIXEpK4pbweXkn54CEiwfI858/FYu2n+Gu+k2iw==",
+      "dev": true,
       "requires": {
         "fontfaceobserver": "^2.0.9"
       }
@@ -22242,24 +22282,28 @@
     "@financial-times/o-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-utils/-/o-utils-2.1.0.tgz",
-      "integrity": "sha512-tYtLU5e+rWedEnVrUYAqm5v8QVS7jBYyglIy8n7J1Bpam/fztcwTuqD2hf5kx8u7ITaapd4Bs0BJ+77k1fFWiw=="
+      "integrity": "sha512-tYtLU5e+rWedEnVrUYAqm5v8QVS7jBYyglIy8n7J1Bpam/fztcwTuqD2hf5kx8u7ITaapd4Bs0BJ+77k1fFWiw==",
+      "dev": true
     },
     "@financial-times/o-viewport": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-viewport/-/o-viewport-5.1.0.tgz",
       "integrity": "sha512-X7A6kA4jeSzZMLDI0bwDLpGou5UIdWj+0FzWhzfsT/ImN9kSMPotKa7T0QPc45OjbquYkWOr5ysq3TXKS2YQkw==",
+      "dev": true,
       "requires": {}
     },
     "@financial-times/o-visual-effects": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@financial-times/o-visual-effects/-/o-visual-effects-4.1.0.tgz",
       "integrity": "sha512-u2FtZ6K/O1QgcwlvDkAwblAgkiAiZ4NNSBDVHuieAn1wB9HjiAvuzbUO66T2k25GfhfXEvmlHM4aAu2FFO7dTw==",
+      "dev": true,
       "requires": {}
     },
     "@financial-times/sass-mq": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@financial-times/sass-mq/-/sass-mq-5.2.2.tgz",
       "integrity": "sha512-RmVzh2Reo67kCZoVJggJEJS+SjSJh1vct6mHYb0olmKYkpx3tNjTESNLDPfbSYyjW5Z3tCoaLF2FW9rqgWRnfg==",
+      "dev": true,
       "peer": true,
       "requires": {}
     },
@@ -27507,7 +27551,8 @@
     "fontfaceobserver": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.1.0.tgz",
-      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng=="
+      "integrity": "sha512-ReOsO2F66jUa0jmv2nlM/s1MiutJx/srhAe2+TE8dJCMi02ZZOcCTxTCQFr3Yet+uODUtnr4Mewg+tNQ+4V1Ng==",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -29926,6 +29971,7 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/mathsass/-/mathsass-0.10.1.tgz",
       "integrity": "sha1-h2j+ICEL1drqttZFxCx+aaTGAAg=",
+      "dev": true,
       "peer": true
     },
     "mdast-util-from-markdown": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,16 @@
   "homepage": "https://github.com/Financial-Times/n-ui-foundations#readme",
   "devDependencies": {
     "@financial-times/n-gage": "^8.3.2",
+    "@financial-times/o-buttons": "^7.2.0",
+    "@financial-times/o-colors": "^6.4.0",
+    "@financial-times/o-fonts": "^5.2.0",
+    "@financial-times/o-grid": "^6.1.1",
+    "@financial-times/o-icons": "^7.2.0",
+    "@financial-times/o-normalise": "^3.2.0",
+    "@financial-times/o-typography": "^7.2.0",
+    "@financial-times/o-utils": "^2.1.0",
+    "@financial-times/o-viewport": "^5.1.0",
+    "@financial-times/o-visual-effects": "^4.1.0",
     "babel-core": "^6.22.1",
     "babel-loader": "^6.2.10",
     "babel-plugin-add-module-exports": "^0.2.1",
@@ -69,6 +79,11 @@
     "npm": "7.20.2"
   },
   "dependencies": {
+    "ftdomdelegate": "^5.0.0",
+    "superstore": "^2.1.0",
+    "superstore-sync": "^2.1.1"
+  },
+  "peerDependencies": {
     "@financial-times/o-buttons": "^7.2.0",
     "@financial-times/o-colors": "^6.4.0",
     "@financial-times/o-fonts": "^5.2.0",
@@ -78,9 +93,6 @@
     "@financial-times/o-typography": "^7.2.0",
     "@financial-times/o-utils": "^2.1.0",
     "@financial-times/o-viewport": "^5.1.0",
-    "@financial-times/o-visual-effects": "^4.1.0",
-    "ftdomdelegate": "^5.0.0",
-    "superstore": "^2.1.0",
-    "superstore-sync": "^2.1.1"
+    "@financial-times/o-visual-effects": "^4.1.0"
   }
 }


### PR DESCRIPTION
To ensure compatibility with apps that will also be depending on these Origami components (or their dependencies), they should be installed as peerDependencies, and additionally as devDependencies for local development and testing. In the future, it may be possible to make the peer deps more permissive, but at this point we have a specific version that we've migrated to from bower.