### PR TITLE
CPP-668 Delete dependencies that were only being used transitively

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,6 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "license": "ISC",
-      "dependencies": {
-        "ftdomdelegate": "^5.0.0",
-        "superstore": "^2.1.0",
-        "superstore-sync": "^2.1.1"
-      },
       "devDependencies": {
         "@financial-times/n-gage": "^8.3.2",
         "@financial-times/o-buttons": "^7.2.0",
@@ -8710,11 +8705,6 @@
       "engines": {
         "node": ">= 4.0"
       }
-    },
-    "node_modules/ftdomdelegate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ftdomdelegate/-/ftdomdelegate-5.0.0.tgz",
-      "integrity": "sha512-P9UmLMIq/ibxxFVBHlE2EIoHcFNDpamn3urRCwVWMnj3o9nAgLtqe64WVuqcGtkN4wujrBYeyxKCuN1/WO+bQw=="
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -18745,25 +18735,6 @@
         "postcss": "^7.0.2"
       }
     },
-    "node_modules/superstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/superstore/-/superstore-2.1.0.tgz",
-      "integrity": "sha1-TNbFsqiyQyXbn+Nz6V/IacHTsiU=",
-      "dependencies": {
-        "superstore-sync": "^2.1.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/superstore-sync": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/superstore-sync/-/superstore-sync-2.1.1.tgz",
-      "integrity": "sha512-p9UZQkOR0JKr4rJFwQubHff8+ktFg8LuIvwR3fYtjra2+m6dTA3LPkf6VQApZaRgaCkYzcDDgAIshM1Ejq0wxQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -27651,11 +27622,6 @@
         "nan": "^2.12.1"
       }
     },
-    "ftdomdelegate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ftdomdelegate/-/ftdomdelegate-5.0.0.tgz",
-      "integrity": "sha512-P9UmLMIq/ibxxFVBHlE2EIoHcFNDpamn3urRCwVWMnj3o9nAgLtqe64WVuqcGtkN4wujrBYeyxKCuN1/WO+bQw=="
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -35624,19 +35590,6 @@
       "requires": {
         "postcss": "^7.0.2"
       }
-    },
-    "superstore": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/superstore/-/superstore-2.1.0.tgz",
-      "integrity": "sha1-TNbFsqiyQyXbn+Nz6V/IacHTsiU=",
-      "requires": {
-        "superstore-sync": "^2.1.0"
-      }
-    },
-    "superstore-sync": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/superstore-sync/-/superstore-sync-2.1.1.tgz",
-      "integrity": "sha512-p9UZQkOR0JKr4rJFwQubHff8+ktFg8LuIvwR3fYtjra2+m6dTA3LPkf6VQApZaRgaCkYzcDDgAIshM1Ejq0wxQ=="
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -78,11 +78,6 @@
     "node": "12.22.5",
     "npm": "7.20.2"
   },
-  "dependencies": {
-    "ftdomdelegate": "^5.0.0",
-    "superstore": "^2.1.0",
-    "superstore-sync": "^2.1.1"
-  },
   "peerDependencies": {
     "@financial-times/o-buttons": "^7.2.0",
     "@financial-times/o-colors": "^6.4.0",


### PR DESCRIPTION
The `superstore`, `superstore-sync`, and `ftdomdelegate` packages were being installed as dependencies for `n-ui-foundations`, but are not actually used anywhere in the code. Rather than this being a simple case of deleting superfluous dependencies, however, this is a holdover feature from the project's time as a bower dependency, where those three dependencies could be installed and used via this package. Using transitive dependencies like this is inappropriate and unstable: it makes the dependency chain hard to follow/audit, and leaves dependents subject to breaking if any of the transitive dependencies are updated or removed from `n-ui-foundations`. Instead, they should be installed as direct dependencies of packages that need them.