### PR TITLE
removed o-assets-global-path referece

### DIFF
--- a/_mixins.scss
+++ b/_mixins.scss
@@ -23,8 +23,6 @@
 // Decide where it's gonna live later
 $spacing-unit: 20px;
 
-$o-assets-global-path: 'https://www.ft.com/__origami/service/build/v2/files/';
-
 // Primitives
 @import 'grid/main';
 @import 'images/main';


### PR DESCRIPTION
Removed o-assets-global-path reference to Build Service v2 used for $o-assets-global-path. o-assets is deprecated, and doesn't work at all with Build Service v3,