### PR TITLE
refactor: don't duplicate the o-normalise helpers

### DIFF
--- a/_mixins.scss
+++ b/_mixins.scss
@@ -33,12 +33,7 @@ $spacing-unit: 20px;
 @import '@financial-times/o-visual-effects/main';
 
 @mixin nUiFoundations {
-
-	@include oNormalise((
-		'elements': ('links', 'text', 'images', 'forms'),
-		'body': ('font-smoothing', 'focus')
-	));
-
+	@include oNormalise;
 	@include nUiGrid;
 	@include nUiTypography;
 	@include nUiUtil;

--- a/util/main.scss
+++ b/util/main.scss
@@ -37,13 +37,4 @@
 	.enhanced .n-ui-hide-enhanced {
 		display: none;
 	}
-
-	// Output o-normalise’s helper classes
-	.o-normalise-clearfix {
-		@include oNormaliseClearfix;
-	}
-
-	.o-normalise-visually-hidden {
-		@include oNormaliseVisuallyHidden;
-	}
 }


### PR DESCRIPTION
`clearfix` and `visually-hidden` are [output by default](https://github.com/Financial-Times/origami/blob/cf35cc001b44f216c64bb456618edc1f5f6b8a17/components/o-normalise/main.scss#L19) by `oNormalise`. for some reason we were telling `oNormalise` not to do that, then doing the exact same thing ourselves.

i've gone a bit further and changed all `oNormalise` options to their default. the only difference is this now includes `reduced-motion`, which outputs utility styles to disable animations when a user has requested that. when [we updated to `o-normalise` v2](https://github.com/Financial-Times/n-ui-foundations/pull/71) this option wasn't available, so by overriding the options we inadvertently weren't getting that feature.