### PR TITLE
feat!: remove $spacing-unit

### DIFF
--- a/_mixins.scss
+++ b/_mixins.scss
@@ -19,10 +19,6 @@
 	/*! end:#{$name}.css*/
 }
 
-// Base unit to standardize spacing
-// Decide where it's gonna live later
-$spacing-unit: 20px;
-
 // Primitives
 @import 'grid/main';
 @import 'typography/main';


### PR DESCRIPTION
i decided where it should live: nowhere

there were only a handful of remaining uses, which will soon all be replaced with `o-spacing`