### PR TITLE
Remove code splitting mixins

### DIFF
--- a/_mixins.scss
+++ b/_mixins.scss
@@ -1,24 +1,3 @@
-/// Stylesheet block
-/// @output Wraps the block with stylesheet start and end comments
-@mixin nUiStylesheet($name) {
-	@include nUiStylesheetStart($name);
-	@content;
-	@include nUiStylesheetEnd($name);
-}
-
-
-/// Stylesheet block start
-/// @output A stylesheet block start comment
-@mixin nUiStylesheetStart($name) {
-	/*! start:#{$name}.css*/
-}
-
-/// Stylesheet block end
-/// @output A stylesheet block start comment
-@mixin nUiStylesheetEnd($name) {
-	/*! end:#{$name}.css*/
-}
-
 // Primitives
 @import 'grid/main';
 @import 'typography/main';


### PR DESCRIPTION
were previously used for CSS code splitting but are no longer in use at all https://github.com/search?q=org%3AFinancial-Times+nUiStylesheet+language%3ASCSS+-repo%3Afinancial-times%2Fdotcom-page-kit+-repo%3Afinancial-times%2Fn-ui+-repo%3Afinancial-times%2Fn-ui-foundations+-is%3Aarchived&type=code