### PR TITLE
feat!: remove default html font size

### DIFF
--- a/typography/main.scss
+++ b/typography/main.scss
@@ -14,11 +14,6 @@
 		)
 	));
 
-	html {
-		font-family: sans-serif;
-		font-size: 0.8125em;
-	}
-
 	a {
 		@include oTypographyLink();
 	}


### PR DESCRIPTION
getting pretty spicy now.

as far as i can tell, this bit of code has existed since 2014, and has been dutifully kept in place across several rounds of moving the code around without anyone wondering if it's actually worth keeping.

it was added to `n-ui-foundations` [in 2017](https://github.com/Financial-Times/n-ui-foundations/commit/aa76cbdce29758ef157a9598a972b4d4d2a86f04), when the repo was first split out from `n-ui`. in that repo it was added (as `0.82em`) in a commit called "[ported typography from next-sass-setup](https://github.com/Financial-Times/n-ui/commit/59621bbde46335b8d205a6c88b60ac77d03d3b07)". `next-sass-setup` was "archived" in 2015. this is before Github actually had an archive feature, so the process at the time was to move the repo to Bitbucket in a project called RIP. Bitbucket was decommissioned in 2017 and the repos archived in an S3 bucket. that bucket is now empty.

since we very very rarely use `em`/`rem` spacing, removing this has almost no effect. the one main problem i've seen removing it cause is in the comments component, which _does_ use `rem`. we'll have to add this font size directly to `next-article` when we update it to a version of `n-ui-foundations`/`dotcom-ui-base-styles` without it, update the font sizes in `o-comments`, then simultaneously update `o-comments` and remove the font size.

### screenshots (warning: _very_ large)

<details><summary>next-home-page</summary>

| before | after |
|-|-|
| ![next-home-page before](https://github.com/user-attachments/assets/b43f463a-f3bb-4219-b352-52c4a27f69d3) | ![next-home-page after](https://github.com/user-attachments/assets/411a9654-33f2-40b3-bebb-9702c662c451) |

</details>


<details><summary>next-article</summary>

| before | after |
|-|-|
| ![next-article before](https://github.com/user-attachments/assets/60f3ac29-749a-42c7-9df8-b34cb3c5a07b) | ![next-article after](https://github.com/user-attachments/assets/ff9311b4-c198-4f40-8898-b12526e0492b) |

</details>

<details><summary>next-stream-page</summary>

| before | after |
|-|-|
| ![next-stream-page before](https://github.com/user-attachments/assets/7402cb90-f4ae-4040-a4b6-54d09333d09b) | 
![next-stream-page after](https://github.com/user-attachments/assets/2107e5f7-0a1e-4962-a512-b44ec3e2f3b6) |

</details>